### PR TITLE
Few tweaks to compose as I was unable to execute

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -50,8 +50,5 @@ DEPENDENCIES
   pry
   rspec
 
-RUBY VERSION
-   ruby 2.3.0p0
-
 BUNDLED WITH
    1.14.6

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,8 @@ services:
 
   elasticsearch:
     image: elasticsearch:2.3.5
-    environment: ['http.host=0.0.0.0', 'transport.host=127.0.0.1']
+    environment:
+      - http.host=0.0.0.0
     restart: always
     ports:
-      - 9200:9200
+      - 9200

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
     command: sh -c './wait-for elasticsearch:9200 -- rspec'
 
   elasticsearch:
-    image: elasticsearch:2.3.5
+    image: elasticsearch:5.5.2
     environment:
       - http.host=0.0.0.0
     restart: always

--- a/spec/calc_spec.rb
+++ b/spec/calc_spec.rb
@@ -9,8 +9,8 @@ describe 'Calculations' do
   # colour: [red, blue]
 
   # Audiences
-  let(:red_likers_audience) { {and: [{colour: [:red]}]} }
-  let(:female_or_not_old_audience) { {or: [{gender: [:female]}, {age: [:young, :middle]}]} }
+  let(:red_likers_audience) { {must: [{colour: [:red]}]} }
+  let(:female_or_not_old_audience) { {should: [{gender: [:female]}, {age: [:young, :middle]}]} }
 
   let(:respondents) do
     [


### PR DESCRIPTION
- I have unblocked the port to be tied directly to local 9200. Docker assignes port atuomatically when not specified. Containers can see each other by the specified port even tho their actual local port
number is randomly generated.
- For some reason the array syntax for elasticsearch's environemnt var wasn't accepted by my linux's docker. Changed to the normal YAML style list.
- Update ES to current stable 5.5